### PR TITLE
Update for v14

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,15 @@
+turnkey-etherpad-14.0 (1) turnkey; urgency=low
+
+  * Etherpad:
+
+    - Latest upstream versions of Etherpad and NodeJS.
+    - Generate/update SESSIONKEY in addition to APIKEY automatically.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <q@dae.pp.ua>  Sun, 17 May 2015 09:18:07 +0300
+
 turnkey-etherpad-13.0 (1) turnkey; urgency=low
 
   * Etherpad:

--- a/conf.d/main
+++ b/conf.d/main
@@ -54,6 +54,8 @@ cat >$NODEAPP/settings.json<<EOF
 EOF
 
 echo -n $(mcookie) > $NODEAPP/APIKEY.txt
+echo -n $(mcookie) > $NODEAPP/SESSIONKEY.txt
+chown nodejs:nodejs $NODEAPP/SESSIONKEY.txt
 
 echo -n "done" > $NODEAPP/src/.ep_initialized
 chown nodejs:nodejs $NODEAPP/src/.ep_initialized

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-etherpad-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-etherpad-secrets
@@ -5,9 +5,11 @@
 
 NODEAPP=/opt/etherpad-lite
 APIKEY=$(mcookie)
+SESSIONKEY=$(mcookie)
 PASSWORD=$(mcookie)
 
 echo -n $APIKEY > $NODEAPP/APIKEY.txt
+echo -n $SESSIONKEY > $NODEAPP/SESSIONKEY.txt
 
 sed -i "s|password.*|password\": \"$PASSWORD\",|" $NODEAPP/settings.json
 $INITHOOKS_PATH/bin/mysqlconf.py --user=etherpad --pass="$PASSWORD"


### PR DESCRIPTION
Etherpad warns in the logfile that there is no admin user defined in the settings file. Should this be made into an inithook?
