### PR TITLE
16.1-update plus 2

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -29,6 +29,7 @@ su node -lc "cd $NODEAPP && ./bin/installDeps.sh"
 su - node -c "cd $NODEAPP && npm install $PLUGINS"
 su - node -c "cd $NODEAPP && npm install bcrypt"
 su - node -c "cd $NODEAPP/src && npm install bcrypt --save"
+su - node -c "cd $NODEAPP && ./src/bin/installDeps.sh"
 
 unset HTTP_PROXY
 


### PR DESCRIPTION
*sigh*...

Hopefully this is the last one...

- Explicitly run `installDeps.sh` to ensure that Etherpad is aware of bcrypt.