### PR TITLE
Update nodejs plan

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -1,7 +1,6 @@
 #include <turnkey/base>
-#include <turnkey/nodejs>
+#include <turnkey/nodejs-nginx>
 #include <turnkey/mysql>
 
-
 tidy            /* improves output of exported pads and only adds 893 kB */
-python3-argon2 /* replaces bcrypt for hashing mechanism*/
+python3-argon2  /* replaces bcrypt for hashing mechanism*/


### PR DESCRIPTION
Update nodejs plan (old `nodejs` plan no longer has nginx).

Part of https://github.com/turnkeylinux/tracker/issues/1772

Also requires:

- https://github.com/turnkeylinux/common/pull/231
- https://github.com/turnkeylinux-apps/ghost/pull/16
- https://github.com/turnkeylinux-apps/mongodb/pull/20
- https://github.com/turnkeylinux-apps/nodejs/pull/15
- https://github.com/turnkeylinux-apps/redis/pull/8